### PR TITLE
Use make to simplify build workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cache/clangd/index
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+WS_ROOT := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+TARGET := hello_world
+
+ifeq ($(OS),Windows_NT)
+    MKDIR := mkdir
+	CP := copy
+	RM := rd /s /q
+	SEP := \\
+else
+    MKDIR := mkdir -p
+	CP := cp
+	RM := rm -rf
+	SEP := /
+endif
+
+build:
+	$(MKDIR) $(WS_ROOT)$(SEP)build
+	cd $(WS_ROOT)$(SEP)build && cmake .. && $(MAKE) -j
+
+run:
+	$(WS_ROOT)$(SEP)build$(SEP)$(TARGET)
+
+clean:
+	$(RM) $(WS_ROOT)$(SEP)build

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ one CUC student's course design
 
 # Build instructions:
 ~~~bash
-mkdir build
-cd build
-cmake ..
-make
-./hello_world
+make build run
 ~~~
 


### PR DESCRIPTION
- [x] `make build`: build the project
- [x] `make run`: launch the build target
- [x] `make clean`: clean build directory && target
- [x] Apply `-j` to `make` for boosted compilation